### PR TITLE
fix(recent-searches)

### DIFF
--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -14,16 +14,9 @@
                                 <item name="component" xsi:type="string">Amadeco_PopularSearchTerms/js/search-terms</item>
                                 <item name="config" xsi:type="array">
                                     <item name="template" xsi:type="string">Amadeco_PopularSearchTerms/search-terms-template</item>
-                                    <!--
-                                    /**
-                                     * Let config handle the rest !
-                                     */
-                                    <item name="max_recent_searches" xsi:type="number">5</item>
-                                    <item name="number_of_terms" xsi:type="number">10</item>
-                                    -->
-                                    <item name="search_form_id" xsi:type="string">minisearch-form-top-search</item>
-                                    <item name="search_input_name" xsi:type="string">q</item>
-                                    <item name="storage_key" xsi:type="string">recent-searches</item>
+                                    <item name="searchFormId" xsi:type="string">minisearch-form-top-search</item>
+                                    <item name="searchInputName" xsi:type="string">q</item>
+                                    <item name="storageKey" xsi:type="string">recent-searches</item>
                                 </item>
                             </item>
                         </item>

--- a/view/frontend/web/js/model/storage.js
+++ b/view/frontend/web/js/model/storage.js
@@ -1,133 +1,83 @@
 /**
  * Amadeco PopularSearchTerms Module
  *
- * @category   Amadeco
- * @package    Amadeco_PopularSearchTerms
- * @author     Ilan Parmentier
+ * @category    Amadeco
+ * @package     Amadeco_PopularSearchTerms
+ * @author      Ilan Parmentier
  */
 define([
     'jquery',
-    'underscore'
-], function($, _) {
+    'underscore',
+    'jquery/jquery-storageapi'
+], function ($, _) {
     'use strict';
 
     /**
-     * Model for managing recent searches using Native LocalStorage
+     * Model for managing recent searches using Magento's jQuery Storage API.
+     * This replaces raw window.localStorage with a robust, namespaced solution.
      */
     return {
-        /**
-         * Default configuration
-         */
         defaults: {
             storageKey: 'recent-searches',
             formId: 'search_mini_form',
             inputName: 'q',
-            namespace: 'amadeco:'
+            namespace: 'amadeco'
         },
 
         /**
-         * State flags
+         * @var {Object}
          */
-        storageAvailable: false,
+        storage: null,
+
+        /**
+         * @var {Object}
+         */
         config: {},
 
         /**
-         * Initialize configuration
+         * Initialize configuration and storage mechanism.
          *
          * @param {Object} config
+         * @return {Object} this
          */
-        initialize: function(config) {
+        initialize: function (config) {
             this.config = _.extend({}, this.defaults, config || {});
-            this.storageAvailable = this._checkStorageAvailability();
+            this.storage = $.initNamespaceStorage(this.config.namespace).localStorage;
+
             return this;
         },
 
         /**
-         * Verify if LocalStorage is supported and available
-         * (Handles Private Browsing mode issues in Safari)
+         * Get recent searches from local storage.
+         * The wrapper automatically handles JSON parsing.
          *
-         * @private
-         * @return {boolean}
+         * @return {Array}
          */
-        _checkStorageAvailability: function() {
-            try {
-                var testKey = '__storage_test__';
-                window.localStorage.setItem(testKey, testKey);
-                window.localStorage.removeItem(testKey);
-                return true;
-            } catch (e) {
-                console.warn('Amadeco SearchTerms: LocalStorage is not available.');
-                return false;
-            }
+        getRecentSearches: function () {
+            var data = this.storage.get(this.config.storageKey);
+            return Array.isArray(data) ? data : [];
         },
 
         /**
-         * Get namespaced key
+         * Add a search term to recent searches.
          *
-         * @private
-         * @return {String}
+         * @param {String} term
+         * @param {Number} maxItems
          */
-        _getKey: function() {
-            return this.config.namespace + this.config.storageKey;
-        },
-
-        /**
-         * Get form selector
-         *
-         * @returns {String}
-         */
-        getFormSelector: function() {
-            return 'form[id="' + this.config.formId + '"]';
-        },
-
-        /**
-         * Get input selector
-         *
-         * @returns {String}
-         */
-        getInputSelector: function() {
-            return 'input[name="' + this.config.inputName + '"]';
-        },
-
-        /**
-         * Get recent searches from local storage
-         *
-         * @returns {Array}
-         */
-        getRecentSearches: function() {
-            if (!this.storageAvailable) {
-                return [];
-            }
-
-            try {
-                var data = window.localStorage.getItem(this._getKey());
-                return data ? JSON.parse(data) : [];
-            } catch (e) {
-                console.error('Error parsing search terms data', e);
-                return [];
-            }
-        },
-
-        /**
-         * Add a search term to recent searches
-         *
-         * @param {string} term
-         * @param {number} maxItems - Maximum number of recent searches to keep
-         */
-        addRecentSearch: function(term, maxItems) {
-            if (!this.storageAvailable || !term) {
+        addRecentSearch: function (term, maxItems) {
+            if (!term) {
                 return;
             }
 
             term = term.trim();
-            if (term === '') {
+            if (term.length === 0) {
                 return;
             }
 
             var recentSearches = this.getRecentSearches();
 
-            // Remove duplicates
-            recentSearches = recentSearches.filter(function(search) {
+            // Remove duplicates (case insensitive)
+            recentSearches = recentSearches.filter(function (search) {
                 return search.query_text.toLowerCase() !== term.toLowerCase();
             });
 
@@ -142,25 +92,39 @@ define([
                 recentSearches = recentSearches.slice(0, maxItems);
             }
 
-            // Save
+            // Save (Storage API handles JSON stringify automatically)
             try {
-                window.localStorage.setItem(this._getKey(), JSON.stringify(recentSearches));
+                this.storage.set(this.config.storageKey, recentSearches);
                 $(document).trigger('recentSearchesUpdated', [recentSearches]);
             } catch (e) {
-                console.error('Error saving search terms', e);
+                console.error('Amadeco SearchTerms: Error saving to storage', e);
             }
         },
 
         /**
-         * Clear all recent searches
+         * Clear all recent searches.
          */
-        clearRecentSearches: function() {
-            if (!this.storageAvailable) {
-                return;
-            }
-
-            window.localStorage.removeItem(this._getKey());
+        clearRecentSearches: function () {
+            this.storage.remove(this.config.storageKey);
             $(document).trigger('recentSearchesUpdated', [[]]);
+        },
+
+        /**
+         * Get form selector based on ID.
+         *
+         * @return {String}
+         */
+        getFormSelector: function () {
+            return '#' + this.config.formId;
+        },
+
+        /**
+         * Get input selector
+         *
+         * @return {String}
+         */
+        getInputSelector: function () {
+            return 'input[name="' + this.config.inputName + '"]';
         },
 
         /**
@@ -171,7 +135,7 @@ define([
         initSearchObserver: function(maxItems) {
             var self = this;
             var formSelector = this.getFormSelector();
-            
+
             // Event delegation is safer if the form is dynamically loaded
             $(document).on('submit', formSelector, function(e) {
                 var inputSelector = self.getInputSelector();

--- a/view/frontend/web/js/search-terms.js
+++ b/view/frontend/web/js/search-terms.js
@@ -20,7 +20,7 @@ define([
     /**
      * Search Terms UI Component
      *
-     * This component manages popular search terms provided by the server 
+     * This component manages popular search terms provided by the server
      * and user search history persisted in LocalStorage.
      *
      * @api
@@ -28,7 +28,7 @@ define([
     return Component.extend({
         /**
          * Component configuration defaults.
-         * These values are automatically overridden by the 'config' array 
+         * These values are automatically overridden by the 'config' array
          * injected by Amadeco\PopularSearchTerms\Block\SearchTerms::getJsLayout.
          */
         defaults: {
@@ -39,11 +39,9 @@ define([
             sortOrder: 'popularity',
             searchResultUrl: '',
             maxRecentSearches: 5,
-            searchForm: {
-                formId: 'search_mini_form',
-                inputName: 'q',
-                storageKey: 'recent-searches'
-            }
+            searchFormId: 'search_mini_form',
+            searchInputName: 'q',
+            storageKey: 'recent-searches'
         },
 
         /**
@@ -60,20 +58,27 @@ define([
             this.error = ko.observable(false);
             this.errorMessage = ko.observable('');
             this.loading = ko.observable(false);
-            
+
             this.hasRecentSearches = ko.pureComputed(function () {
                 return this.recentSearches().length > 0;
             }, this);
 
             // 2. Initialize Persistence Model
-            // Values like this.searchForm and this.maxRecentSearches are now 
+            // Values like this.searchForm and this.maxRecentSearches are now
             // natively available thanks to the Block injection.
-            storageModel.initialize(this.searchForm);
+            var storageConfig = {
+                formId: this.searchFormId,
+                inputName: this.searchInputName,
+                storageKey: this.storageKey
+            };
+
+            console.log(storageConfig);
+            storageModel.initialize(storageConfig);
             storageModel.initSearchObserver(parseInt(this.maxRecentSearches, 10));
 
             // 3. Load initial data
             this.loadRecentSearches();
-            
+
             // 4. AJAX Loading Trigger
             if (this.ajaxUrl && this.terms().length === 0) {
                 this.fetchTerms();


### PR DESCRIPTION
fix(recent-searches): issue with retrieval of configuration.
feat(storage): use jquery storage API.
refactor(PopularSearchTerms): modernize SearchTerms block to PHP 8.3

Refactors the SearchTerms block to align with PHP 8.3 strict typing and
Amadeco's clean code standards. This change improves maintainability,
readability, and type safety without altering the external behavior of
the component.

Changes:
- Implement PHP 8.3 constructor property promotion with `readonly`.
- Define typed constants (e.g., `private const int`).
- Extract configuration logic into `getComponentConfig` to reduce cyclomatic complexity in `getJsLayout`.
- Use `array_replace_recursive` for robust configuration merging.
- Enforce strict return types across all methods.
- Optimize cache key generation using spread operator.